### PR TITLE
[feat] Implemented showing on cluster info the first featured image o…

### DIFF
--- a/app/src/main/java/com/madteam/sunset/model/SpotClusterItem.kt
+++ b/app/src/main/java/com/madteam/sunset/model/SpotClusterItem.kt
@@ -11,7 +11,8 @@ data class SpotClusterItem(
     val name: String,
     val spot: DocumentReference,
     val location: GeoPoint,
-    val isSelected: Boolean
+    val isSelected: Boolean,
+    val featuredImage: String
 ) : ClusterItem {
 
     constructor() : this(
@@ -19,7 +20,8 @@ data class SpotClusterItem(
         name = "",
         spot = FirebaseFirestore.getInstance().document(""),
         location = GeoPoint(0.0, 0.0),
-        isSelected = false
+        isSelected = false,
+        featuredImage = ""
     )
 
     override fun getTitle() = name

--- a/app/src/main/java/com/madteam/sunset/repositories/DatabaseRepository.kt
+++ b/app/src/main/java/com/madteam/sunset/repositories/DatabaseRepository.kt
@@ -210,14 +210,16 @@ class DatabaseRepository @Inject constructor(
                 val name = document.getString("name")
                 val location = document.getGeoPoint("location")
                 val spot = document.getDocumentReference("spot")
+                val image = document.getString("image")
 
-                if (name != null && location != null && spot != null) {
+                if (name != null && location != null && spot != null && image != null) {
                     SpotClusterItem(
                         id = id,
                         name = name,
                         spot = spot,
                         location = location,
-                        isSelected = false
+                        isSelected = false,
+                        featuredImage = image
                     )
                 } else {
                     null
@@ -725,7 +727,8 @@ class DatabaseRepository @Inject constructor(
         val newSpotLocation = hashMapOf(
             "location" to GeoPoint(spotLocation.latitude, spotLocation.longitude),
             "name" to spotTitle,
-            "spot" to newSpotDocument
+            "spot" to newSpotDocument,
+            "image" to featuredImagesList.first()
         )
 
         newSpotDocument.set(newSpot).await()

--- a/app/src/main/java/com/madteam/sunset/ui/screens/discover/SpotClusterInfo.kt
+++ b/app/src/main/java/com/madteam/sunset/ui/screens/discover/SpotClusterInfo.kt
@@ -48,7 +48,7 @@ fun SpotClusterInfo(
                     modifier = Modifier
                         .fillMaxHeight()
                         .fillMaxWidth(0.4f),
-                    model = "https://t4.ftcdn.net/jpg/01/04/78/75/360_F_104787586_63vz1PkylLEfSfZ08dqTnqJqlqdq0eXx.jpg",
+                    model = selectedCluster.featuredImage,
                     contentDescription = "Image of Sunset Spot",
                     contentScale = ContentScale.Crop
                 )


### PR DESCRIPTION
## 📝 Description

Implemented showing the first featured image of a spot on the spot cluster info preview when tapping a cluster on discover screen

### 📎 Utils links

- [x] Jira ticket:  https://adrifernandevs.atlassian.net/jira/software/projects/SA/boards/2?selectedIssue=SA-181
