### PR TITLE
[fix] When result code is not OK it cancels loading

### DIFF
--- a/app/src/main/java/com/madteam/sunset/ui/screens/welcome/ui/WelcomeScreen.kt
+++ b/app/src/main/java/com/madteam/sunset/ui/screens/welcome/ui/WelcomeScreen.kt
@@ -73,6 +73,8 @@ fun WelcomeScreen(
                         GoogleSignIn.getSignedInAccountFromIntent(intent)
                     viewModel.onEvent(WelcomeUIEvent.HandleGoogleSignInResult(task.result as GoogleSignInAccount))
                 }
+            } else {
+                viewModel.onEvent(WelcomeUIEvent.ShowLoading(false))
             }
         }
 


### PR DESCRIPTION
## 📝 Description

When a user clicks login with google and before choosing an account press backs or closes the SSO Google modal it gets stucks with loading because the result code of the launcher wasn't OK. Now it is being handled and it doesn't happen anymore.

## ✅ How to test

Go to welcome screen and clicks login with google, then press back.

### 📎 Utils links

- [x] Jira ticket: https://adrifernandevs.atlassian.net/browse/SA-342
