### PR TITLE
Feature/sa 353 implement in app updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,6 +120,10 @@ dependencies {
     // Google AdMob
     implementation(libs.play.services.ads)
 
+    //Google Play App Updates
+    implementation(libs.play.app.updates)
+    implementation(libs.play.app.updates.ktx)
+
     // Compose
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)

--- a/app/src/main/java/com/madteam/sunset/MainActivity.kt
+++ b/app/src/main/java/com/madteam/sunset/MainActivity.kt
@@ -79,6 +79,7 @@ class MainActivity : ComponentActivity() {
                 "minVersion" to BuildConfig.VERSION_NAME
             )
         )
+        remoteConfig.fetchAndActivate()
     }
 
     private fun checkIfUpdateIsAvailable() {

--- a/app/src/main/java/com/madteam/sunset/MainActivity.kt
+++ b/app/src/main/java/com/madteam/sunset/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.madteam.sunset
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -12,17 +14,27 @@ import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import com.google.android.gms.ads.MobileAds
+import com.google.android.play.core.appupdate.AppUpdateInfo
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.UpdateAvailability
 import com.madteam.sunset.data.repositories.AuthRepository
 import com.madteam.sunset.navigation.SunsetNavigation
 import com.madteam.sunset.ui.theme.SunsetTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
+private const val FLEXIBLE_UPDATE_REQUEST_CODE = 33
+private const val IMMEDIATE_UPDATE_REQUEST_CODE = 69
+
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var authRepository: AuthRepository
+
+    private lateinit var appUpdateManager: AppUpdateManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -47,5 +59,50 @@ class MainActivity : ComponentActivity() {
 
         //Init AdMob
         MobileAds.initialize(this) {}
+
+        //Init In-App Update
+        appUpdateManager = AppUpdateManagerFactory.create(this)
+        checkIfUpdateIsAvailable()
     }
+
+    private fun checkIfUpdateIsAvailable() {
+        val appUpdateInfoTask = appUpdateManager.appUpdateInfo
+        appUpdateInfoTask.addOnSuccessListener { appUpdateInfo ->
+            if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+                && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
+                && appUpdateInfo.updatePriority() >= 4
+            ) {
+                startAppUpdate(
+                    appUpdateInfo,
+                    AppUpdateType.IMMEDIATE,
+                    IMMEDIATE_UPDATE_REQUEST_CODE
+                )
+            } else if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+                && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+            ) {
+                startAppUpdate(appUpdateInfo, AppUpdateType.FLEXIBLE, FLEXIBLE_UPDATE_REQUEST_CODE)
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == IMMEDIATE_UPDATE_REQUEST_CODE) {
+            when (resultCode) {
+                Activity.RESULT_CANCELED -> {
+                    finish()
+                }
+            }
+        }
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    private fun startAppUpdate(updateInfo: AppUpdateInfo, updateType: Int, requestCode: Int) {
+        appUpdateManager.startUpdateFlowForResult(
+            updateInfo,
+            updateType,
+            this,
+            requestCode
+        )
+    }
+
 }

--- a/app/src/main/java/com/madteam/sunset/di/FirebaseModule.kt
+++ b/app/src/main/java/com/madteam/sunset/di/FirebaseModule.kt
@@ -9,6 +9,8 @@ import com.google.firebase.database.ktx.database
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.ktx.remoteConfig
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.ktx.storage
 import dagger.Module
@@ -41,5 +43,9 @@ object FirebaseModule {
     @Singleton
     @Provides
     fun providesFirebaseDatabase(): FirebaseDatabase = Firebase.database
+
+    @Singleton
+    @Provides
+    fun providesFirebaseConfig(): FirebaseRemoteConfig = Firebase.remoteConfig
 
 }

--- a/app/src/main/java/com/madteam/sunset/ui/screens/welcome/ui/WelcomeScreen.kt
+++ b/app/src/main/java/com/madteam/sunset/ui/screens/welcome/ui/WelcomeScreen.kt
@@ -140,7 +140,7 @@ fun WelcomeScreen(
         is Resource.Success -> {
             if (state.signInState.data != null) {
                 LaunchedEffect(key1 = state.signInState.data) {
-                    navController.navigate(SunsetRoutes.MyProfileScreen.route) {
+                    navController.navigate(SunsetRoutes.HomeScreen.route) {
                         popUpTo(navController.graph.id) {
                             inclusive = true
                         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ glide = "1.0.0-alpha.1"
 roomKtx = "2.6.0"
 play-services-auth = "20.7.0"
 secretsGradlePlugin = "2.0.1"
+play-app-updates = "2.0.1"
 
 
 [libraries]
@@ -84,3 +85,5 @@ compose-material = { module = "androidx.compose.material:material" }
 compose-material-icons = { module = "androidx.compose.material:material-icons-extended" }
 secrets-gradle-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "secretsGradlePlugin" }
 play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "play-services-auth" }
+play-app-updates = { group = "com.google.android.play", name = "app-update", version.ref = "play-app-updates" }
+play-app-updates-ktx = { group = "com.google.android.play", name = "app-update-ktx", version.ref = "play-app-updates" }


### PR DESCRIPTION
## 📝 Description
Implemented In-App updates with the play update API. It has been implemented two types of updates, flexible and immediate, when a flexible update is called it means that it has no priority on installing (minor UI changes or minor new features that does not affect to the security) it'll show like this: 

https://github.com/Mad-Development-Team/Sunset-Android-App/assets/128298030/8995f101-b9b6-4bdd-ad2c-1a258b91687e

The user can cancel without problem and can update while using the app, when the update is completed it'll be installed the next time the user restarts the app.

When an update is with high priority it'll update on immediate way, it'll show like this:

https://github.com/Mad-Development-Team/Sunset-Android-App/assets/128298030/9836508a-675c-48f4-9cf2-6cabf53445b2

It'll block the app until the user updates (here is not happening because of the REQUEST_CODE)

## 📢 Annotations

**How to set the priority of the update?** 
Set the value versionForce to true and the minVersion on RemoteConfig.


### 📎 Utils links

- [x] Jira ticket: https://adrifernandevs.atlassian.net/browse/SA-353
